### PR TITLE
Typo on YoikScreenOrientation.m

### DIFF
--- a/src/ios/YoikScreenOrientation.m
+++ b/src/ios/YoikScreenOrientation.m
@@ -57,7 +57,7 @@
                 orientation = @"portrait-secondary";
                 break;
             default:
-                orientation = @"portait";
+                orientation = @"portrait";
                 break;
         }
 


### PR DESCRIPTION
Typo that can make -(UIInterfaceOrientationMask) supportedInterfaceOrientations: to return UIInterfaceOrientationMaskAll if for some reason the switch for the current orientation enters the default branch.
