### PR TITLE
CB-12271 (windows) Fixed "platform add" error, added new tests

### DIFF
--- a/src/windows/CDVOrientationProxy.js
+++ b/src/windows/CDVOrientationProxy.js
@@ -20,11 +20,11 @@
 */
 
 var DisplayInfo = Windows.Graphics.Display.DisplayInformation;
-    var Orientations = Windows.Graphics.Display.DisplayOrientations;
+var Orientations = Windows.Graphics.Display.DisplayOrientations;
 
 module.exports = {
-    setAllowedOrientations: function (win, fail, args) {
-        //console.log("setAllowedOrientations proxy called with " + args);
+    screenOrientation: function (win, fail, args) {
+        //console.log("screenOrientation proxy called with " + args);
 
         try {
             var prefOrients = args[0];

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -29,8 +29,24 @@ exports.defineAutoTests = function() {
 
     it("should contain a platform specification that is a string", function() {
       expect(window.orientation).toBeDefined();
-      expect((String(window.orientation.type)).length > 0).toBe(true);
+      if (window.orientation) {
+        expect((String(window.orientation.type)).length > 0).toBe(true);
+      }
     });
 
+    it("should successfully lock and unlock screen orientation", function (done) {
+      try {
+        screen.lockOrientation('landscape').then(function () {
+          expect(screen.unlockOrientation).not.toThrow();
+          done();
+        }, function (err) {
+          fail('Promise was rejected: ' + err);
+          done();
+        });
+      } catch (e) {
+        fail(e);
+        done();
+      }
+    });
   });
 };


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Windows

### What does this PR do?
Fixes an error on plugin add to windows project. Also, adds a couple of tests to test sanity of `screen.lockOrientation()` and `screen.unlockOrientation()` methods.
https://issues.apache.org/jira/browse/CB-12271

### What testing has been done on this change?
Automated paramedic testing on Windows and Android.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
