### PR TITLE
CB-12285 Polyfill promises on platforms that doesn't support them nat…

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -64,12 +64,15 @@
         </js-module>
     </platform>
 
-
-
     <platform name="windows">
         <js-module src="src/windows/CDVOrientationProxy.js" name="CDVOrientationProxy">
             <merges target="" />
         </js-module>
     </platform>
+
+    <dependency
+        id="es6-promise-plugin"
+        url="https://github.com/vstirbu/PromisesPlugin.git">
+    </dependency>
 
 </plugin>


### PR DESCRIPTION
…ively

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
All platforms with webview that doesn't support promises natively. For example, Android API level 19.

### What does this PR do?
Includes a polyfill library so the promises (and therefore, `.lockScreen` function) would work everywhere.

### What testing has been done on this change?
Paramedic tests on Android API 19.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
