### PR TITLE
CB-12543 (iOS) Set orientation on when locking the device

### DIFF
--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -52,6 +52,25 @@
     
     if([vc respondsToSelector:selector]) {
         ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
+        
+        if ([UIDevice currentDevice] != nil){
+            NSNumber *value = nil;
+            if(orientationMask == 8 || orientationMask == 12) {
+                value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
+            } else if (orientationMask == 4){
+                value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
+            } else if (orientationMask == 1 || orientationMask == 3) {
+                value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
+            } else if (orientationMask == 2) {
+                value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
+            }
+            if (value != nil) {
+                [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
+            }
+        }
+        
+        [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
+        
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     }
     else {

--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -69,12 +69,10 @@
             }
         }
         
-        [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
-        
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     }
     else {
-        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_INVALID_ACTION                messageAsString:@"Error calling to set supported orientations"];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_INVALID_ACTION messageAsString:@"Error calling to set supported orientations"];
     }
     
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];

--- a/src/windows/CDVOrientationProxy.js
+++ b/src/windows/CDVOrientationProxy.js
@@ -53,6 +53,6 @@ module.exports = {
         }
 
     }
-}
+};
 
 require("cordova/exec/proxy").add("CDVOrientation", module.exports);

--- a/www/screenorientation.js
+++ b/www/screenorientation.js
@@ -54,7 +54,7 @@
         screenObject.lock = function(orientation) {
             var promiseLock;
             var p = new Promise(function(resolve, reject) {
-                if (screenObject.nativeLock !== null) {
+                if (screenObject.nativeLock != null) {
                     promiseLock = screenObject.nativeLock(orientation);
                     promiseLock.then(function success(res) {
                     resolve();

--- a/www/screenorientation.js
+++ b/www/screenorientation.js
@@ -54,7 +54,7 @@
         screenObject.lock = function(orientation) {
             var promiseLock;
             var p = new Promise(function(resolve, reject) {
-                if (screenObject.nativeLock != null) {
+                if (screenObject.nativeLock !== null) {
                     promiseLock = screenObject.nativeLock(orientation);
                     promiseLock.then(function success(res) {
                     resolve();
@@ -65,9 +65,9 @@
                 } else {
                     resolveOrientation(orientation, resolve, reject);
                 }
-            })
+            });
             return p;
-        }
+        };
 
         screenObject.unlock = function() {
             screenOrientation.setOrientation('any');
@@ -94,7 +94,7 @@
 
     function orientationChange() {
         screen.orientation.type = window.OrientationType[window.orientation];
-               
+
     }
     window.addEventListener("orientationchange", orientationChange, true);
     module.exports = screenOrientation;


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
Instead of just locking the orientation, it also rotates to it. Mandatory for iOS.

### What testing has been done on this change?
Manual testing on iOS 10, iPhone 6+.
Run: "npm test"

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [] Added automated test coverage as appropriate for this change.
