### PR TITLE
fix(plugin): add es6-promise-plugin from npm

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,7 @@
             </feature>
         </config-file>
 
-        <dependency id="es6-promise-plugin" url="https://github.com/vstirbu/PromisesPlugin.git"/>
+        <dependency id="es6-promise-plugin" version="4.1.0" />
 
     </platform>
 


### PR DESCRIPTION
With cordova 7+, when trying to install the plugin, this error occurs 

![](https://puu.sh/vNM8u/b84e2d683c.png)

So I changed the `dependency` tag to use the version instead of the url, so it fetches the plugin from npm instead of github.