### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
   "devDependencies": {
     "jshint": "^2.9.4"
   },
+  "peerDependencies": {
+    "@ionic-native/core": "^3.6.1"
+  },
   "engines": {
     "cordovaDependencies": {
       "3.0.0": {


### PR DESCRIPTION
minor change

The plugin uses IonicNativePlugin from ionic-native / core version (3.6.1), so plugin need to have this specified, for earlier versions it causes error: https://stackoverflow.com/questions/43650747/module-has-no-exported-member-ionicnativeplugin-ionic2
