### PR TITLE
CB-12994: (android, blackberry) add es6-promise-plugin from npm

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -52,7 +52,7 @@
             </feature>
         </config-file>
 
-        <dependency id="es6-promise-plugin" url="https://github.com/vstirbu/PromisesPlugin.git"/>
+        <dependency id="es6-promise-plugin" version="^4.1.0" />
 
     </platform>
 
@@ -64,7 +64,7 @@
         <js-module src="www/screenorientation.bb10.js" name="screenorientation.bb10">
             <merges target="cordova.plugins.screenorientation" />
         </js-module>
-        <dependency id="es6-promise-plugin" url="https://github.com/vstirbu/PromisesPlugin.git"/>
+        <dependency id="es6-promise-plugin" version="^4.1.0"/>
     </platform>
 
     <platform name="windows">


### PR DESCRIPTION
this closes #15

### Platforms affected
android, blackberry

### What does this PR do?
https://issues.apache.org/jira/browse/CB-12994
Changes the plugin to not install es6-promise-plugin dependency from git, but instead install it from npm.

### What testing has been done on this change?
Travis and AppVeyor are going to do all the testing

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
