### PR TITLE
CB-13405: (ios) Go to last used orientation before locking when unlocking screen on iOS

### DIFF
--- a/src/ios/CDVOrientation.h
+++ b/src/ios/CDVOrientation.h
@@ -24,7 +24,10 @@
 #import <Cordova/CDVViewController.h>
 
 @interface CDVOrientation : CDVPlugin
-{}
+{
+@protected
+    UIInterfaceOrientation _lastOrientation;
+}
 
 - (void)screenOrientation:(CDVInvokedUrlCommand *)command;
 

--- a/src/ios/CDVOrientation.h
+++ b/src/ios/CDVOrientation.h
@@ -26,6 +26,7 @@
 @interface CDVOrientation : CDVPlugin
 {
 @protected
+    BOOL _isLocked;
     UIInterfaceOrientation _lastOrientation;
 }
 

--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -55,17 +55,25 @@
         
         if ([UIDevice currentDevice] != nil){
             NSNumber *value = nil;
-            if(orientationMask == 8 || orientationMask == 12) {
-                value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
-            } else if (orientationMask == 4){
-                value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
-            } else if (orientationMask == 1 || orientationMask == 3) {
-                value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
-            } else if (orientationMask == 2) {
-                value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
+            if (orientationMask != 15) {
+                _lastOrientation = [UIApplication sharedApplication].statusBarOrientation;
+                if(orientationMask == 8 || orientationMask == 12) {
+                    value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
+                } else if (orientationMask == 4){
+                    value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
+                } else if (orientationMask == 1 || orientationMask == 3) {
+                    value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
+                } else if (orientationMask == 2) {
+                    value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
+                }
+            } else {
+                if (_lastOrientation != nil) {
+                    value = [NSNumber numberWithInt:_lastOrientation];
+                }
             }
             if (value != nil) {
                 [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
+                [UINavigationController attemptRotationToDeviceOrientation];
             }
         }
         


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS

### What does this PR do?
When screen is locked and then unlocked, the screen does not rotate back to however the user is or was holding the device.  This makes it so that the screen is rotated back to the way the screen was before being locked.  

### What testing has been done on this change?
Testing on iPhone 6, emulator

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
