### PR TITLE
CB-13193: (ios) Fixed Lock iOS Landscape Orientation turn up-sidedown

### DIFF
--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -42,10 +42,10 @@
         [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown]];
     }
     if(orientationMask & 4) {
-        [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft]];
+        [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight]];
     }
     if(orientationMask & 8) {
-        [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight]];
+        [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft]];
     }
     
     SEL selector = NSSelectorFromString(@"setSupportedOrientations:");
@@ -61,11 +61,12 @@
                 if (!_isLocked) {
                     _lastOrientation = [UIApplication sharedApplication].statusBarOrientation;
                 }
-                if(orientationMask == 8 || orientationMask == 12) {
-                    value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
-                } else if (orientationMask == 4){
+                UIInterfaceOrientation deviceOrientation = [UIApplication sharedApplication].statusBarOrientation;
+                if(orientationMask == 8  || (orientationMask == 12  && !UIInterfaceOrientationIsLandscape(deviceOrientation))) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
-                } else if (orientationMask == 1 || orientationMask == 3) {
+                } else if (orientationMask == 4){
+                    value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
+                } else if (orientationMask == 1 || (orientationMask == 3 && !UIInterfaceOrientationIsPortrait(deviceOrientation))) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
                 } else if (orientationMask == 2) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];


### PR DESCRIPTION
### Platforms affected
iOS

### What does this PR do?
In iOS, the Landscape have opposite orientation.
Meaning if you do below when you are in landscape orientation, then you will notice the screen flips to opposite landscape orientation.
screen.orientation.lock(screen.orientation.type);

### What testing has been done on this change?
Manual testing on iPhone has been done.
