### PR TITLE
Fix unlock

### DIFF
--- a/src/android/CDVOrientation.java
+++ b/src/android/CDVOrientation.java
@@ -48,13 +48,20 @@ public class CDVOrientation extends CordovaPlugin {
     private static final String LANDSCAPE = "landscape";
     
     @Override
-    public boolean execute(String action, JSONArray args, CallbackContext callbackContext) {
+    public boolean execute(String action, JSONArray args, final CallbackContext callbackContext) {
         
         Log.d(TAG, "execute action: " + action);
-        
+
         // Route the Action
         if (action.equals("screenOrientation")) {
-            return routeScreenOrientation(args, callbackContext);
+            final String orientation = args.optString(1);
+            cordova.getThreadPool().execute(new Runnable() {
+                @Override
+                public void run() {
+                    routeScreenOrientation(orientation, callbackContext);
+                }
+            });
+            return true;
         }
         
         // Action not found
@@ -62,13 +69,7 @@ public class CDVOrientation extends CordovaPlugin {
         return false;
     }
     
-    private boolean routeScreenOrientation(JSONArray args, CallbackContext callbackContext) {
-        
-        String action = args.optString(0);
-        
-        
-        
-        String orientation = args.optString(1);
+    private void routeScreenOrientation(String orientation, CallbackContext callbackContext) {
         
         Log.d(TAG, "Requested ScreenOrientation: " + orientation);
         
@@ -91,8 +92,6 @@ public class CDVOrientation extends CordovaPlugin {
         }
         
         callbackContext.success();
-        return true;
-        
-        
+
     }
 }

--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -68,7 +68,6 @@
                 } else if (orientationMask == 2) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
                 }
-                [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
             } else {
                 [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationUnknown] forKey:@"orientation"];
                 ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);

--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -56,8 +56,8 @@
         }
         
         if ([UIDevice currentDevice] != nil){
+            NSNumber *value = nil;
             if (orientationMask != 15) {
-                NSNumber *value = nil;
                 UIInterfaceOrientation deviceOrientation = [UIApplication sharedApplication].statusBarOrientation;
                 if(orientationMask == 8  || (orientationMask == 12  && !UIInterfaceOrientationIsLandscape(deviceOrientation))) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];

--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -47,7 +47,7 @@
     if(orientationMask & 8) {
         [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft]];
     }
-    
+
     SEL selector = NSSelectorFromString(@"setSupportedOrientations:");
     
     if([vc respondsToSelector:selector]) {
@@ -56,11 +56,8 @@
         }
         
         if ([UIDevice currentDevice] != nil){
-            NSNumber *value = nil;
             if (orientationMask != 15) {
-                if (!_isLocked) {
-                    _lastOrientation = [UIApplication sharedApplication].statusBarOrientation;
-                }
+                NSNumber *value = nil;
                 UIInterfaceOrientation deviceOrientation = [UIApplication sharedApplication].statusBarOrientation;
                 if(orientationMask == 8  || (orientationMask == 12  && !UIInterfaceOrientationIsLandscape(deviceOrientation))) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
@@ -71,12 +68,11 @@
                 } else if (orientationMask == 2) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
                 }
+                [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
             } else {
-                if (_lastOrientation != UIInterfaceOrientationUnknown) {
-                    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:_lastOrientation] forKey:@"orientation"];
-                    ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
-                    [UINavigationController attemptRotationToDeviceOrientation];
-                }
+                [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:UIInterfaceOrientationUnknown] forKey:@"orientation"];
+                ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
+                [UINavigationController attemptRotationToDeviceOrientation];
             }
             if (value != nil) {
                 _isLocked = true;


### PR DESCRIPTION
### Platforms affected
iOS and Android

### What does this PR do?
After `unlock` is made on iOS it sets orientation to `UIInterfaceOrientationUnknown` so that phone decides by its own to which orientation change or not after unlocking.

Additionaly it fixes cordova warning on Android:

    THREAD WARNING: exec() call to CDVOrientation.screenOrientation blocked the main thread for 94ms. Plugin should use CordovaInterface.getThreadPool()

### What testing has been done on this change?
Manual testing on Android and iOS devices

### Checklist
https://issues.apache.org/jira/browse/CB-13983