### PR TITLE
refactor(ios): Simplify the IOS orientation logic

### DIFF
--- a/src/ios/CDVOrientation.h
+++ b/src/ios/CDVOrientation.h
@@ -24,11 +24,7 @@
 #import <Cordova/CDVViewController.h>
 
 @interface CDVOrientation : CDVPlugin
-{
-@protected
-    BOOL _isLocked;
-    UIInterfaceOrientation _lastOrientation;
-}
+{}
 
 - (void)screenOrientation:(CDVInvokedUrlCommand *)command;
 

--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -51,41 +51,27 @@
     SEL selector = NSSelectorFromString(@"setSupportedOrientations:");
     
     if([vc respondsToSelector:selector]) {
-        if (orientationMask != 15 || [UIDevice currentDevice] == nil) {
-            ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
-        }
-        
+        // Set valid orientations
+        ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
+
         if ([UIDevice currentDevice] != nil){
-            NSNumber *value = nil;
             if (orientationMask != 15) {
                 if (!_isLocked) {
                     _lastOrientation = [UIApplication sharedApplication].statusBarOrientation;
                 }
-                UIInterfaceOrientation deviceOrientation = [UIApplication sharedApplication].statusBarOrientation;
-                if(orientationMask == 8  || (orientationMask == 12  && !UIInterfaceOrientationIsLandscape(deviceOrientation))) {
-                    value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
-                } else if (orientationMask == 4){
+                if(orientationMask == 8 || orientationMask == 12) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
                 } else if (orientationMask == 1 || (orientationMask == 3 && !UIInterfaceOrientationIsPortrait(deviceOrientation))) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
                 } else if (orientationMask == 2) {
                     value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
                 }
-            } else {
-                if (_lastOrientation != UIInterfaceOrientationUnknown) {
-                    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:_lastOrientation] forKey:@"orientation"];
-                    ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
-                    [UINavigationController attemptRotationToDeviceOrientation];
-                }
-            }
-            if (value != nil) {
-                _isLocked = true;
                 [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
             } else {
-                _isLocked = false;
+                // Unlock orientation
+                [UINavigationController attemptRotationToDeviceOrientation];
             }
         }
-        
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     }
     else {


### PR DESCRIPTION
## Motivation

Fix invalid behavior with screen orientation and make it consistent with other platforms.

## What cases we actually fix

When user do not lock screen first then unlock will not work properly.
For IOS lock is required in order to unlock that after.
System preferences apply to the app as well.

Another issue is that if you lock device twice to different orientation (for example on different screens). Unlock will restore that to the only first one.

Previous logic was really complex with lots of if cases that were already covered and repetition.

Note: Change that caused this bug: https://github.com/apache/cordova-plugin-screen-orientation/pull/24

Ticket logged by community: https://issues.apache.org/jira/browse/CB-14079