### PR TITLE
fix: resolveOrientation function not working correctly

### DIFF
--- a/www/screenorientation.js
+++ b/www/screenorientation.js
@@ -84,7 +84,7 @@ function addScreenOrientationApi (screenObject) {
 }
 
 function resolveOrientation (orientation, resolve, reject) {
-    if (!Object.prototype.hasOwnProperty.call(OrientationLockType, 'orientation')) {
+    if (!Object.prototype.hasOwnProperty.call(OrientationLockType, orientation)) {
         var err = new Error();
         err.name = 'NotSupportedError';
         reject(err); // "cannot change orientation");


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Android


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
It fixes an issue that when invoking the set orientation it was checking for 'orientation' instead of variable value



### Testing
<!-- Please describe in detail how you tested your changes. -->
Manual testing on Android 


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
