### PR TITLE
fix(ios): #100 - Resolve orientation issues on iOS 16+

### DIFF
--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -80,7 +80,13 @@
             }
             if (value != nil) {
                 _isLocked = true;
-                [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
+                if (@available(iOS 16.0, *)) {
+                    #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_15_5 // Xcode 14 and iOS 16, or greater
+                        [self.viewController setNeedsUpdateOfSupportedInterfaceOrientations];
+                    #endif
+                } else {
+                    [UINavigationController attemptRotationToDeviceOrientation];
+                }
             } else {
                 _isLocked = false;
             }

--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -80,11 +80,12 @@
             }
             if (value != nil) {
                 _isLocked = true;
+                #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_15_5
                 if (@available(iOS 16.0, *)) {
-                    #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_15_5 // Xcode 14 and iOS 16, or greater
                         [self.viewController setNeedsUpdateOfSupportedInterfaceOrientations];
-                    #endif
-                } else {
+                } else
+                #endif
+                {
                     [UINavigationController attemptRotationToDeviceOrientation];
                 }
             } else {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS 16 or newer

### Motivation and Context
It fixes #100 



### Description
Screen orientation is not working for iOS 16 devices. This fix is confirmed by many other users on the issue thread.



### Testing
<!-- Please describe in detail how you tested your changes. -->
I forked this repo and tested it internally on one of our client apps. I was able to have the issue, implement this fix, and confirm the issue no longer existed: https://github.com/521dimensions/cordova-plugin-screen-orientation


### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [X] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [X] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [X] I've updated the documentation if necessary
