### PR TITLE
chore: npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org
+


### PR DESCRIPTION
Adds `.npmrc` file to assert that the official NPM registry is used during for NPM commands.

Progresses https://github.com/apache/cordova/issues/299