### PR TITLE
feat(ios): add support for ios 16

### DIFF
--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -61,8 +61,7 @@
     }
 }
 
-
-#if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_15_5
+#if __IPHONE_OS_VERSION_MAX_ALLOWED >= 160000
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunguarded-availability-new"
 // this will stop it complaining about new iOS16 APIs being used.

--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -28,6 +28,74 @@
 
 @implementation CDVOrientation
 
+-(void)handleAboveEqualIos16WithOrientationMask:(NSInteger) orientationMask viewController: (CDVViewController*) vc result:(NSMutableArray*) result selector:(SEL) selector
+{
+    if(@available(iOS 16.0, *)) {
+        NSObject *value16;
+        // oritentationMask 15 is "unlock" the orientation lock.
+        if (orientationMask != 15) {
+            if (!_isLocked) {
+                _lastOrientation = [UIApplication sharedApplication].statusBarOrientation;
+            }
+            UIInterfaceOrientation deviceOrientation = [UIApplication sharedApplication].statusBarOrientation;
+            if(orientationMask == 8  || (orientationMask == 12  && !UIInterfaceOrientationIsLandscape(deviceOrientation))) {
+                value16 = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskLandscapeLeft];
+            } else if (orientationMask == 4){
+                value16 = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskLandscapeRight];
+            } else if (orientationMask == 1 || (orientationMask == 3 && !UIInterfaceOrientationIsPortrait(deviceOrientation))) {
+                value16 = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskPortrait];
+            } else if (orientationMask == 2) {
+                value16 = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskPortraitUpsideDown];
+            }
+        } else {
+            ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
+        }
+        if (value16 != nil) {
+            _isLocked = true;
+            UIWindowScene *scene = (UIWindowScene*)[[UIApplication.sharedApplication connectedScenes] anyObject];
+            [scene requestGeometryUpdateWithPreferences:(UIWindowSceneGeometryPreferencesIOS*)value16 errorHandler:^(NSError * _Nonnull error) {
+                NSLog(@"Failed to change orientation  %@ %@", error, [error userInfo]);
+            }];
+        } else {
+            _isLocked = false;
+        }
+    }
+}
+
+
+-(void)handleBelowEqualIos15WithOrientationMask:(NSInteger) orientationMask viewController: (CDVViewController*) vc result:(NSMutableArray*) result selector:(SEL) selector
+{
+    NSValue *value;
+    if (orientationMask != 15) {
+        if (!_isLocked) {
+            _lastOrientation = [UIApplication sharedApplication].statusBarOrientation;
+        }
+        UIInterfaceOrientation deviceOrientation = [UIApplication sharedApplication].statusBarOrientation;
+        if(orientationMask == 8  || (orientationMask == 12  && !UIInterfaceOrientationIsLandscape(deviceOrientation))) {
+            value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
+        } else if (orientationMask == 4){
+            value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
+        } else if (orientationMask == 1 || (orientationMask == 3 && !UIInterfaceOrientationIsPortrait(deviceOrientation))) {
+            value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
+        } else if (orientationMask == 2) {
+            value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
+        }
+    } else {
+        if (_lastOrientation != UIInterfaceOrientationUnknown) {
+            [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:_lastOrientation] forKey:@"orientation"];
+            ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
+            [UINavigationController attemptRotationToDeviceOrientation];
+        }
+    }
+    if (value != nil) {
+        _isLocked = true;
+        [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
+    } else {
+        _isLocked = false;
+    }
+}
+
+
 -(void)screenOrientation:(CDVInvokedUrlCommand *)command
 {
     CDVPluginResult* pluginResult;
@@ -47,42 +115,22 @@
     if(orientationMask & 8) {
         [result addObject:[NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft]];
     }
-    
     SEL selector = NSSelectorFromString(@"setSupportedOrientations:");
     
     if([vc respondsToSelector:selector]) {
         if (orientationMask != 15 || [UIDevice currentDevice] == nil) {
             ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
         }
-        
+
         if ([UIDevice currentDevice] != nil){
-            NSNumber *value = nil;
-            if (orientationMask != 15) {
-                if (!_isLocked) {
-                    _lastOrientation = [UIApplication sharedApplication].statusBarOrientation;
-                }
-                UIInterfaceOrientation deviceOrientation = [UIApplication sharedApplication].statusBarOrientation;
-                if(orientationMask == 8  || (orientationMask == 12  && !UIInterfaceOrientationIsLandscape(deviceOrientation))) {
-                    value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeLeft];
-                } else if (orientationMask == 4){
-                    value = [NSNumber numberWithInt:UIInterfaceOrientationLandscapeRight];
-                } else if (orientationMask == 1 || (orientationMask == 3 && !UIInterfaceOrientationIsPortrait(deviceOrientation))) {
-                    value = [NSNumber numberWithInt:UIInterfaceOrientationPortrait];
-                } else if (orientationMask == 2) {
-                    value = [NSNumber numberWithInt:UIInterfaceOrientationPortraitUpsideDown];
-                }
+            if (@available(iOS 16.0, *)) {
+                [self handleAboveEqualIos16WithOrientationMask:orientationMask viewController:vc result:result selector:selector];
+                // always double check the supported interfaces, so we update if needed
+                // but do it right at the end here to avoid the "double" rotation issue reported in
+                // https://github.com/apache/cordova-plugin-screen-orientation/pull/107
+                [self.viewController setNeedsUpdateOfSupportedInterfaceOrientations];
             } else {
-                if (_lastOrientation != UIInterfaceOrientationUnknown) {
-                    [[UIDevice currentDevice] setValue:[NSNumber numberWithInt:_lastOrientation] forKey:@"orientation"];
-                    ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
-                    [UINavigationController attemptRotationToDeviceOrientation];
-                }
-            }
-            if (value != nil) {
-                _isLocked = true;
-                [[UIDevice currentDevice] setValue:value forKey:@"orientation"];
-            } else {
-                _isLocked = false;
+                [self handleBelowEqualIos15WithOrientationMask:orientationMask viewController:vc result:result selector:selector];
             }
         }
         

--- a/src/ios/CDVOrientation.m
+++ b/src/ios/CDVOrientation.m
@@ -67,7 +67,7 @@
 // this will stop it complaining about new iOS16 APIs being used.
 -(void)handleAboveEqualIos16WithOrientationMask:(NSInteger) orientationMask viewController: (CDVViewController*) vc result:(NSMutableArray*) result selector:(SEL) selector
 {
-    NSObject *value16;
+    NSObject *value;
     // oritentationMask 15 is "unlock" the orientation lock.
     if (orientationMask != 15) {
         if (!_isLocked) {
@@ -75,21 +75,21 @@
         }
         UIInterfaceOrientation deviceOrientation = [UIApplication sharedApplication].statusBarOrientation;
         if(orientationMask == 8  || (orientationMask == 12  && !UIInterfaceOrientationIsLandscape(deviceOrientation))) {
-            value16 = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskLandscapeLeft];
+            value = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskLandscapeLeft];
         } else if (orientationMask == 4){
-            value16 = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskLandscapeRight];
+            value = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskLandscapeRight];
         } else if (orientationMask == 1 || (orientationMask == 3 && !UIInterfaceOrientationIsPortrait(deviceOrientation))) {
-            value16 = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskPortrait];
+            value = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskPortrait];
         } else if (orientationMask == 2) {
-            value16 = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskPortraitUpsideDown];
+            value = [[UIWindowSceneGeometryPreferencesIOS alloc] initWithInterfaceOrientations:UIInterfaceOrientationMaskPortraitUpsideDown];
         }
     } else {
         ((void (*)(CDVViewController*, SEL, NSMutableArray*))objc_msgSend)(vc,selector,result);
     }
-    if (value16 != nil) {
+    if (value != nil) {
         _isLocked = true;
         UIWindowScene *scene = (UIWindowScene*)[[UIApplication.sharedApplication connectedScenes] anyObject];
-        [scene requestGeometryUpdateWithPreferences:(UIWindowSceneGeometryPreferencesIOS*)value16 errorHandler:^(NSError * _Nonnull error) {
+        [scene requestGeometryUpdateWithPreferences:(UIWindowSceneGeometryPreferencesIOS*)value errorHandler:^(NSError * _Nonnull error) {
             NSLog(@"Failed to change orientation  %@ %@", error, [error userInfo]);
         }];
     } else {


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Apple devices running iOS 16


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
resolves #100  
<!-- If it fixes an open issue, please link to the issue here. -->
Currently orientation is broken on iOS 16 with
`Setting UIDevice.orientation is not supported. Please use UIWindowScene.requestGeometryUpdate(_:)`


### Description
<!-- Describe your changes in detail -->
deprecate on whether iOS 16 is available - either use the old method or the new one.


### Testing
<!-- Please describe in detail how you tested your changes. -->
confirmed on iPhone 11 running iOS 15 and iPhone 13 Pro running iOS 16.
I have not confirmed all features work, but simply setting orientations works - the old pre iOS 16 should be unaffected.

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
