### PR TITLE
fix(R7-9625): fix plugin for use with webpack

### DIFF
--- a/www/screenorientation.js
+++ b/www/screenorientation.js
@@ -47,8 +47,12 @@ screenOrientation.setOrientation = function (orientation) {
     cordova.exec(null, null, 'CDVOrientation', 'screenOrientation', [orientationMask, orientation]);
 };
 
-if (!screen.orientation) {
-    screen.orientation = {};
+if (!window.screen) {
+    window.screen = {};
+}
+
+if (!window.screen.orientation) {
+    window.screen.orientation = {};
 }
 
 setOrientationProperties();
@@ -94,18 +98,18 @@ function resolveOrientation (orientation, resolve, reject) {
     }
 }
 
-addScreenOrientationApi(screen.orientation);
+addScreenOrientationApi(window.screen.orientation);
 
 var onChangeListener = null;
 
-Object.defineProperty(screen.orientation, 'onchange', {
+Object.defineProperty(window.screen.orientation, 'onchange', {
     set: function (listener) {
         if (onChangeListener) {
-            screen.orientation.removeEventListener('change', onChangeListener);
+            window.screen.orientation.removeEventListener('change', onChangeListener);
         }
         onChangeListener = listener;
         if (onChangeListener) {
-            screen.orientation.addEventListener('change', onChangeListener);
+            window.screen.orientation.addEventListener('change', onChangeListener);
         }
     },
     get: function () {
@@ -122,33 +126,33 @@ var orientationchange = function () {
     evtTarget.dispatchEvent(event);
 };
 
-screen.orientation.addEventListener = function (a, b, c) {
+window.screen.orientation.addEventListener = function (a, b, c) {
     return evtTarget.addEventListener(a, b, c);
 };
 
-screen.orientation.removeEventListener = function (a, b, c) {
+window.screen.orientation.removeEventListener = function (a, b, c) {
     return evtTarget.removeEventListener(a, b, c);
 };
 
 function setOrientationProperties () {
     switch (window.orientation) {
     case 0:
-        screen.orientation.type = 'portrait-primary';
+        window.screen.orientation.type = 'portrait-primary';
         break;
     case 90:
-        screen.orientation.type = 'landscape-primary';
+        window.screen.orientation.type = 'landscape-primary';
         break;
     case 180:
-        screen.orientation.type = 'portrait-secondary';
+        window.screen.orientation.type = 'portrait-secondary';
         break;
     case -90:
-        screen.orientation.type = 'landscape-secondary';
+        window.screen.orientation.type = 'landscape-secondary';
         break;
     default:
-        screen.orientation.type = 'portrait-primary';
+        window.screen.orientation.type = 'portrait-primary';
         break;
     }
-    screen.orientation.angle = window.orientation || 0;
+    window.screen.orientation.angle = window.orientation || 0;
 }
 window.addEventListener('orientationchange', orientationchange, true);
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

All (js)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Fixes builds when package is consumed into webpack.
Original PR: https://github.com/apache/cordova-plugin-screen-orientation/pull/74
This is a rebased version since the OP didn't respond for 2 years.

closes https://github.com/apache/cordova-plugin-screen-orientation/pull/74
fixes https://github.com/apache/cordova-plugin-screen-orientation/issues/73

### Description
<!-- Describe your changes in detail -->

Explictly use `window` for global variable access.
All work was done by the original committer.

### Testing
<!-- Please describe in detail how you tested your changes. -->

Ran `npm test` & cordova-paramedic locally (against android@11)

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
