### PR TITLE
fix: support ios 16.4

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -29,6 +29,7 @@
 
     <js-module src="www/screenorientation.js" name="screenorientation">
         <clobbers target="cordova.plugins.screenorientation" />
+        <clobbers target="screen.orientation" />
     </js-module>
 
     <platform name="ios">

--- a/www/screenorientation.js
+++ b/www/screenorientation.js
@@ -47,10 +47,6 @@ screenOrientation.setOrientation = function (orientation) {
     cordova.exec(null, null, 'CDVOrientation', 'screenOrientation', [orientationMask, orientation]);
 };
 
-if (!screen.orientation) {
-    screen.orientation = {};
-}
-
 setOrientationProperties();
 
 function addScreenOrientationApi (screenObject) {
@@ -94,18 +90,18 @@ function resolveOrientation (orientation, resolve, reject) {
     }
 }
 
-addScreenOrientationApi(screen.orientation);
+addScreenOrientationApi(screenOrientation);
 
 var onChangeListener = null;
 
-Object.defineProperty(screen.orientation, 'onchange', {
+Object.defineProperty(screenOrientation, 'onchange', {
     set: function (listener) {
         if (onChangeListener) {
-            screen.orientation.removeEventListener('change', onChangeListener);
+            screenOrientation.removeEventListener('change', onChangeListener);
         }
         onChangeListener = listener;
         if (onChangeListener) {
-            screen.orientation.addEventListener('change', onChangeListener);
+            screenOrientation.addEventListener('change', onChangeListener);
         }
     },
     get: function () {
@@ -122,33 +118,33 @@ var orientationchange = function () {
     evtTarget.dispatchEvent(event);
 };
 
-screen.orientation.addEventListener = function (a, b, c) {
+screenOrientation.addEventListener = function (a, b, c) {
     return evtTarget.addEventListener(a, b, c);
 };
 
-screen.orientation.removeEventListener = function (a, b, c) {
+screenOrientation.removeEventListener = function (a, b, c) {
     return evtTarget.removeEventListener(a, b, c);
 };
 
 function setOrientationProperties () {
     switch (window.orientation) {
     case 0:
-        screen.orientation.type = 'portrait-primary';
+        screenOrientation.type = 'portrait-primary';
         break;
     case 90:
-        screen.orientation.type = 'landscape-primary';
+        screenOrientation.type = 'landscape-primary';
         break;
     case 180:
-        screen.orientation.type = 'portrait-secondary';
+        screenOrientation.type = 'portrait-secondary';
         break;
     case -90:
-        screen.orientation.type = 'landscape-secondary';
+        screenOrientation.type = 'landscape-secondary';
         break;
     default:
-        screen.orientation.type = 'portrait-primary';
+        screenOrientation.type = 'portrait-primary';
         break;
     }
-    screen.orientation.angle = window.orientation || 0;
+    screenOrientation.angle = window.orientation || 0;
 }
 window.addEventListener('orientationchange', orientationchange, true);
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
iOS 16.4


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
iOS 16.4 supports screen.orientation, causing the plugin to not work properly
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->
The Safari screen.orientation api cannot be extended, causing the original method conflict to fail



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ x] I've run the tests to see all new and existing tests pass
- [ x] I added automated test coverage as appropriate for this change
- [ x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
